### PR TITLE
Add options for min/max/native zoom for baseLayers

### DIFF
--- a/browser/modules/baseLayer.js
+++ b/browser/modules/baseLayer.js
@@ -20,7 +20,14 @@ module.exports = module.exports = {
             bl = window.setBaseLayers[i];
             if (typeof bl.type !== "undefined" && bl.type === "XYZ") {
                 customBaseLayer = new L.TileLayer(bl.url, {
-                    attribution: bl.attribution
+                    attribution: bl.attribution,
+
+                    // Set zoom levels from config, if they are there, else default
+                    // to [0-18] (native), [0-20] (interpolated)
+                    minZoom: (typeof bl.minZoom != "undefined" ? bl.minZoom : 0),
+                    maxZoom: (typeof bl.maxZoom != "undefined" ? bl.maxZoom : 20),
+                    maxNativeZoom: (typeof bl.maxNativeZoom != "undefined" ? bl.maxNativeZoom : 18)
+
                 });
                 customBaseLayer.baseLayer = true;
                 customBaseLayer.id = bl.id;

--- a/config/config.dist.js
+++ b/config/config.dist.js
@@ -12,7 +12,10 @@ module.exports = {
                 id: "my_map",
                 name: "My nice baselayer",
                 description: "Pretty awesome map",
-                attribution: ""
+                attribution: "",
+                minZoom: 0,
+                maxZoom: 18,
+                maxNativeZoom: 20
             },
             {"id": "osm", "name": "OSM"},
             {"id": "stamenToner", "name": "Stamen Toner"}


### PR DESCRIPTION
How does this look?

If min- and maxZoom are not defined, they default to 0 and 18 in leaflet. We tile our baseLayers down to 20, and would possibly like to go even further by interpolating.

It seems that the OSM/Stamen maps goes to 18 zoom, and supports interpolating to 20, so that is what I chose for defaults.