### PR TITLE
Fix conflictSearch on drawn items

### DIFF
--- a/extensions/conflictSearch/server/index.js
+++ b/extensions/conflictSearch/server/index.js
@@ -111,7 +111,8 @@ router.post('/api/extension/conflictSearch', function (req, response) {
                     if (obj[hit].hits > 0) {
                         let data = [];
                         let name = obj[hit].title || obj[hit].table;
-                        name = name.slice(0, 30); // TODO also strip invalid characters
+                        name = name.slice(0, 30); // Excel sheet name max 31 characters
+                        name = name.replace(/[/\\?*[\]]/g, '_'); // handle sheetname invalid characters \ / ? * [ ]
                         if (names.includes(name)) {
                             name = name.slice(0, -1) + postfixNumber;
                             postfixNumber++;


### PR DESCRIPTION
This fixes the issue with wicket not wanting to create valid wkt from geometrycollection. Also forces type = Feature on single selected item.

multiple items will be passed, bufferd and unioned into a single multipolygon for wicket to parse.