### PR TITLE
Print area unit

### DIFF
--- a/browser/modules/utils.js
+++ b/browser/modules/utils.js
@@ -12,22 +12,20 @@ module.exports = {
     },
     init: function () {
     },
-    formatArea: (areaInSquareMeters) => {
-        let result = Math.round(areaInSquareMeters);
-        let ha = (Math.round(areaInSquareMeters / 10000 * 1000) / 1000);
-        let km2 = (Math.round(areaInSquareMeters / 1000000 * 1000) / 1000);
-        if (areaInSquareMeters < 10000) {
-            // Display square meters
-            result = (Math.round(areaInSquareMeters) + ' m2');
-        } else if (areaInSquareMeters >= 10000 && areaInSquareMeters < 1000000) {
-            // Display hectars
-            result = (ha + ' ha');
-        } else if (areaInSquareMeters >= 1000000) {
-            // Display square kilometers and hectars
-            result = (km2 + ' km² (' + ha + ' ha)');
+    formatArea: (a) => {
+        let unit= '';
+        if (a > 100000) {
+          a = a / 100000;
+          unit = 'km²';
+        } else {
+          unit = 'm²';
         }
-
-        return result;
+        if (a < 100) {
+                return a.toFixed(1) + ' ' + unit;
+          } else {
+                return Math.round(a) + ' ' + unit;
+          }
+        }
     },
     /**
      * @todo Remove deprecated "height" parameter

--- a/browser/modules/utils.js
+++ b/browser/modules/utils.js
@@ -24,7 +24,7 @@ module.exports = {
             result = (ha + ' ha');
         } else if (areaInSquareMeters >= 1000000) {
             // Display square kilometers and hectars
-            result = (km2 + ' km2 (' + ha + ' ha)');
+            result = (km2 + ' km² (' + ha + ' ha)');
         }
 
         return result;

--- a/browser/modules/utils.js
+++ b/browser/modules/utils.js
@@ -13,18 +13,18 @@ module.exports = {
     init: function () {
     },
     formatArea: (a) => {
-        let unit= '';
-        if (a > 100000) {
-          a = a / 100000;
+        let unit= 'm²';
+        const bigArea= 100000;
+
+        if (a > bigArea) {
+          a = a / bigArea;
           unit = 'km²';
-        } else {
-          unit = 'm²';
-        }
+        } 
+
         if (a < 100) {
-                return a.toFixed(1) + ' ' + unit;
-          } else {
-                return Math.round(a) + ' ' + unit;
-          }
+          return a.toFixed(1) + ' ' + unit;
+        } else {
+          return Math.round(a) + ' ' + unit;
         }
     },
     /**

--- a/public/js/lib/leaflet-measure-path/leaflet-measure-path.js
+++ b/public/js/lib/leaflet-measure-path/leaflet-measure-path.js
@@ -117,7 +117,7 @@
         }
     }
 
-    let formatArea = function(area) {
+    var formatArea = function(area) {
         if (this._measurementOptions.imperial) {
             let unit;
             if (area > 404.685642) {
@@ -127,9 +127,10 @@
                 area = area / 0.09290304;
                 unit = 'ft²';
             }
-            return (area < 100 ) ?
-            area.toFixed(1) + ' ' + unit:
-            Math.round(area) + ' ' + unit;
+            if (area < 100 ) {
+              return area.toFixed(1) + ' ' + unit;
+            }
+            return Math.round(area) + ' ' + unit;
         } 
         area = Math.round(area); 
         if (area < 10000) {
@@ -312,10 +313,9 @@
 
             if (isPolygon && options.showArea && latLngs.length > 2) {
                 formatter = options.formatArea || L.bind(this.formatArea, this);
-                let area = this.ringArea(latLngs);
-                let resultArea= this.formatArea(area);
+                let area = ringArea(latLngs);
                 L.marker.measurement(this.getBounds().getCenter(),
-                resultArea, options.lang.totalArea, 0, options)
+                formatter(area), options.lang.totalArea, 0, options)
                     .addTo(this._measurementLayer);
             }
         },

--- a/public/js/lib/leaflet-measure-path/leaflet-measure-path.js
+++ b/public/js/lib/leaflet-measure-path/leaflet-measure-path.js
@@ -117,32 +117,32 @@
         }
     }
 
-    var formatArea = function(area) {
+    var formatArea = function(a) {
+        var unit,
+            sqfeet;
+
         if (this._measurementOptions.imperial) {
-            let unit;
-            if (area > 404.685642) {
-                area = area / 4046.85642;
+            if (a > 404.685642) {
+                a = a / 4046.85642;
                 unit = 'ac';
             } else {
-                area = area / 0.09290304;
+                a = a / 0.09290304;
                 unit = 'ft²';
             }
-            if (area < 100 ) {
-              return area.toFixed(1) + ' ' + unit;
+        } else {
+            if (a > 100000) {
+                a = a / 100000;
+                unit = 'km²';
+            } else {
+                unit = 'm²';
             }
-            return Math.round(area) + ' ' + unit;
-        } 
-        area = Math.round(area); 
-        if (area < 10000) {
-           return (area + ' m²');
         }
-        let ha = (Math.round(area / 10000 * 1000) / 1000);
-        
-        if (area >= 10000 && area < 1000000) {
-            return ha + ' ha';
+
+        if (a < 100) {
+            return a.toFixed(1) + ' ' + unit;
+        } else {
+            return Math.round(a) + ' ' + unit;
         }
-        let km2 = (Math.round(area / 1000000 * 1000) / 1000);
-        return (km2 + ' km² (' + ha + ' ha)');
     }
 
     var RADIUS = 6378137;

--- a/public/js/lib/leaflet-measure-path/leaflet-measure-path.js
+++ b/public/js/lib/leaflet-measure-path/leaflet-measure-path.js
@@ -117,32 +117,31 @@
         }
     }
 
-    var formatArea = function(a) {
-        var unit,
-            sqfeet;
-
+    let formatArea = function(area) {
         if (this._measurementOptions.imperial) {
-            if (a > 404.685642) {
-                a = a / 4046.85642;
+            let unit;
+            if (area > 404.685642) {
+                area = area / 4046.85642;
                 unit = 'ac';
             } else {
-                a = a / 0.09290304;
+                area = area / 0.09290304;
                 unit = 'ft²';
             }
-        } else {
-            if (a > 100000) {
-                a = a / 100000;
-                unit = 'km²';
-            } else {
-                unit = 'm²';
-            }
+            return (area < 100 ) ?
+            area.toFixed(1) + ' ' + unit:
+            Math.round(area) + ' ' + unit;
+        } 
+        area = Math.round(area); 
+        if (area < 10000) {
+           return (area + ' m²');
         }
-
-        if (a < 100) {
-            return a.toFixed(1) + ' ' + unit;
-        } else {
-            return Math.round(a) + ' ' + unit;
+        let ha = (Math.round(area / 10000 * 1000) / 1000);
+        
+        if (area >= 10000 && area < 1000000) {
+            return ha + ' ha';
         }
+        let km2 = (Math.round(area / 1000000 * 1000) / 1000);
+        return (km2 + ' km² (' + ha + ' ha)');
     }
 
     var RADIUS = 6378137;
@@ -256,8 +255,8 @@
             this.updateMeasurements();
         }),
 
-        formatDistance: formatDistance,
-        formatArea: formatArea,
+         formatDistance: formatDistance,
+         formatArea: formatArea,
 
         updateMeasurements: function() {
             if (!this._measurementLayer) return;
@@ -313,9 +312,10 @@
 
             if (isPolygon && options.showArea && latLngs.length > 2) {
                 formatter = options.formatArea || L.bind(this.formatArea, this);
-                var area = ringArea(latLngs);
+                let area = this.ringArea(latLngs);
+                let resultArea= this.formatArea(area);
                 L.marker.measurement(this.getBounds().getCenter(),
-                    formatter(area), options.lang.totalArea, 0, options)
+                resultArea, options.lang.totalArea, 0, options)
                     .addTo(this._measurementLayer);
             }
         },


### PR DESCRIPTION
when creating af measure area the method formatArea in  browser/modules/util.js constructs the label for the area size in square meters or ha depending on the actual area size.

When the measure layer is redraw a later render, the method formatArea in public/js/leaflet-measure-path.js is used.
This method do not result in the same label.
It is a problem that two methods exists for the same task. The result is that the area label change when the map is re-opened after digitizing or when printing.

In this pull request the result is more or less the same - in the leaflet-measure-path.js version this._measurementOptions.imperial  is uses the units ac and ft², which don't exists in the Util.js version