### PR TITLE
Fix: Subgroups in layertree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [CalVer](https://calver.org/).
 
+## [unreleased]
+### Fixed
+- Bug in `layerTree` caused subgroups to not be turned on when the parent group was turned on.
+
 ## [2024.11.1] - 2024-21-11
 ### Fixed
 - Editor now handles JSON fields, which before rendered an syntax error in the decoding. 

--- a/browser/modules/layerTree/index.js
+++ b/browser/modules/layerTree/index.js
@@ -4150,7 +4150,10 @@ module.exports = {
                     }
                     return false;
                 }).length;
-                activeLayersInSubGroups += activeLayers.filter(e => JSON.parse(metaDataKeys[layerTreeUtils.stripPrefix(e)].meta)?.vidi_sub_group.match(re) && metaDataKeys[layerTreeUtils.stripPrefix(e)].layergroup === layerGroup).length;
+                activeLayersInSubGroups += activeLayers.filter(e => 
+                    JSON.parse(metaDataKeys[layerTreeUtils.stripPrefix(e)]?.meta)?.vidi_sub_group &&
+                    JSON.parse(metaDataKeys[e].meta)?.vidi_sub_group.match(re) && 
+                    metaDataKeys[e].layergroup === layerGroup).length;
                 const searchPath = `[data-gc2-group-id="${layerGroup}"]` + ' ' + split.map(e => `[data-gc2-subgroup-id="${e}"]`).join(' ') + ` [data-gc2-subgroup-name="${split[split.length - 1]}"]`;
                 const el = document.querySelector(searchPath);
                 if (el) {


### PR DESCRIPTION
PR for #292

This PR fixes the issue with layers in subgroups not turning on when the entire group is.