### PR TITLE
Feature: Custom zoom on extraSearches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [CalVer](https://calver.org/).
 
+## [unreleased]
+### Added
+- New option for setting the zoom-level of custom searches. default is level 18. The value can be set in the config, using the key `zoom`:
+```javascript
+{
+    searchConfig: {
+        size: 4,
+        komkode: "*",
+        esrSearchActive: true,
+        sfeSearchActive: true, // Example of config for danish search
+        extraSearches: [,{
+            name: "stednavne_search",
+            db: "dk",
+            host: "https://dk.gc2.io",
+            heading: "Stednavne",
+            zoom: 20,
+            index: {
+                name: "stednavne/navne_samlet",
+                field: "string",
+                key: "gid",
+
+            },
+            relation: {
+                name: "stednavne.navne_samlet_geom",
+                key: "gid",
+                geom: "the_geom"
+            }
+        }]
+    }
+}
+```
+
 ## [2024.11.1] - 2024-21-11
 ### Fixed
 - Editor now handles JSON fields, which before rendered an syntax error in the decoding. 

--- a/browser/modules/search/danish.js
+++ b/browser/modules/search/danish.js
@@ -155,7 +155,7 @@ module.exports = {
 
         if (!onLoad) {
             onLoad = function () {
-                cloud.get().zoomToExtentOfgeoJsonStore(this, maxZoom);
+                cloud.get().zoomToExtentOfgeoJsonStore(this, this?.zoom || maxZoom);
                 if (advanced) {
                     this.layer._vidi_type = "draw"
                     this.layer.eachLayer((l) => {
@@ -1263,6 +1263,7 @@ module.exports = {
                         placeStores[key] = getPlaceStore();
                         placeStores[key].db = extraSearchesObj[name].db;
                         placeStores[key].host = extraSearchesObj[name]?.host || '';
+                        placeStores[key].zoom = extraSearchesObj[name]?.zoom || maxZoom;
                         placeStores[key].sql = "SELECT *,ST_asgeojson(ST_transform(" + extraSearchesObj[name].relation.geom + ",4326)) as geojson FROM " + extraSearchesObj[name].relation.name + " WHERE " + extraSearchesObj[name].relation.key + "='" + gids[name][datum.value] + "'";
                         if (!extraSearchesObj[name]?.host) {
                             placeStores[key].uri = '/api/sql'

--- a/docs/pages/standard/91_run_configuration.rst
+++ b/docs/pages/standard/91_run_configuration.rst
@@ -7,7 +7,7 @@ Kørselskonfiguration (configs)
 .. topic:: Overview
 
     :Date: |today|
-    :Vidi-version: 2020.11.0
+    :Vidi-version: 2024.11.0
     :Forfattere: `giovanniborella <https://github.com/giovanniborella>`_ | `mapcentia <https://github.com/mapcentia>`_
 
 .. contents::
@@ -155,6 +155,7 @@ Her kan det valgte søgemodul konfigureres.
 * ``sfeSearchActive`` Aktiver søgning på sfe ejendomsnummer
 * ``placeholderText`` Udskift standard-teksten med en anden
 * ``google`` Google API key.
+* ``extraSearches`` Liste af ekstra søgninger.
 
 .. code-block:: json
 
@@ -169,6 +170,32 @@ Her kan det valgte søgemodul konfigureres.
 
 .. note::
     Indstillerne har kun indflydelse på "danish" søgemodulet Kun "google" vedrører Google Place Search og behøver ikke udfyldes, hvis det ikke bruges. Google API kan også sættes i GC2.
+
+Det er muligt at opsætte flere søgemoduler, blandt andet ved at udstille et eller flere lag i en elasticsearch. For at implementere lagene i søgefeltet, skal lagene tilføjes til konfigurationen.
+
+De ekstra søgemoduler kan opsættes således:
+
+.. code-block:: json
+
+    searchConfig: {
+        extraSearches: [,{
+            name: "stednavne_search",
+            db: "dk",
+            host: "https://dk.gc2.io",
+            heading: "Stednavne",
+            zoom: 20, // Zoomniveau, når der klikkes på et søgeresultat
+            index: {
+                name: "stednavne/navne_samlet",
+                field: "string",
+                key: "gid",
+            },
+            relation: {
+                name: "stednavne.navne_samlet_geom",
+                key: "gid",
+                geom: "the_geom"
+            }
+        }]
+    },
 
 .. _configjs_template:
 


### PR DESCRIPTION
In multiple of our usecases, we have a need for setting the zoom-level when searching for an object. we may need it to be higher when dealing with a well or other utilities, and lower for something like plans or other projects. 

This PR:

- [x] Added functionality for setting a custom 
- [x] Updated changelog
- [x] Updated documentation for setting extraSearches with the added parameter