### PR TITLE
ConflictSearch: Defaults not loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [CalVer](https://calver.org/).
 ### Fixed
 - Bug in editor caused layers with restrictions to be output as textareas. Now the editor will correctly output a select with the values setup in GC2.
 - On mobile, it was possible for the menu to get into a stuck transparent state. This has been fixed.
+- A bug caused the defaults not to load in the `conflictSearch` module. This has been fixed.
 
 ## [2024.11.1] - 2024-21-11
 ### Fixed

--- a/extensions/conflictSearch/browser/index.js
+++ b/extensions/conflictSearch/browser/index.js
@@ -277,36 +277,12 @@ module.exports = module.exports = {
     init: function () {
         var metaData, me = this, startBuffer, getProperty;
 
-        try {
-            startBuffer = config.extensionConfig.conflictSearch.startBuffer;
-        } catch (e) {
-            startBuffer = 40;
-        }
-
-        try {
-            getProperty = config.extensionConfig.conflictSearch.getProperty;
-        } catch (e) {
-            getProperty = false;
-        }
-
-        try {
-            searchStr = config.extensionConfig.conflictSearch.searchString;
-            if (searchStr === undefined) {
-                searchStr = "";
-            }
-        } catch (e) {
-            searchStr = "";
-        }
-
-        try {
-            searchLoadedLayers = config.extensionConfig.conflictSearch.searchLoadedLayers;
-            if (searchLoadedLayers === undefined) {
-                searchLoadedLayers = true;
-            }
-        } catch (e) {
-            searchLoadedLayers = true;
-        }
-
+        // Set Defaults
+        startBuffer = config.extensionConfig?.conflictSearch?.startBuffer || 40;
+        getProperty = config.extensionConfig?.conflictSearch?.getProperty || false;
+        searchStr = config.extensionConfig?.conflictSearch?.searchString || "";
+        searchLoadedLayers = config.extensionConfig?.conflictSearch?.searchLoadedLayers || true;
+          
         // Set up draw module for conflict
         draw.setConflictSearch(this);
         $("#_draw_make_conflict_with_selected").show();


### PR DESCRIPTION
when using the `conflictSearch`-extension, defaults have stopped loading. giving the starting buffer a value of 'undefined'.

this PR fixes this issue, and takes an approach for setting the rest of the values correctly to the old defaults if they do not exist in the extensionconfig.