### PR TITLE
Add missing deps for build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,7 @@
         "react": "^16.13.1",
         "react-addons": "^0.9.1-deprecated",
         "react-autocomplete": "^1.8.1",
+        "react-button": "^1.2.1",
         "react-color": "^2.19.3",
         "react-datetime": "^2.16.3",
         "react-dom": "^16.13.1",
@@ -3104,6 +3105,7 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "opencollective",
@@ -3122,6 +3124,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@restart/context/-/context-2.1.4.tgz",
       "integrity": "sha512-INJYZQJP7g+IoDUh/475NlGiTeMfwTXUEr3tmRneckHIxNolGOW9CTq83S8cxq0CgJwwcMzMJFchxvlwe7Rk8Q==",
+      "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "react": ">=16.3.2"
@@ -4910,6 +4913,7 @@
       "version": "2.2.37",
       "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.37.tgz",
       "integrity": "sha512-IwpIMieE55oGWiXkQPSBY1nw1nFs6bsKXTFskNY8sdS17K24vyEBRQZEwlRS7ZmXCWnJcQtbxWzly+cODWGs2A==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/@types/jss": {
@@ -4922,9 +4926,9 @@
       }
     },
     "node_modules/@types/leaflet": {
-      "version": "1.9.12",
-      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.12.tgz",
-      "integrity": "sha512-BK7XS+NyRI291HIo0HCfE18Lp8oA30H1gpi1tf0mF3TgiCEzanQjOqNZ4x126SXzzi2oNSZhZ5axJp1k0iM6jg==",
+      "version": "1.9.15",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.15.tgz",
+      "integrity": "sha512-7UuggAuAs+mva66gtf2OTB1nEhzU/9JED93TIaOEgvFMvG/dIGQaukHE7izHo1Zd+Ko1L4ETUw7TBc8yUxevpg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4996,6 +5000,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
       "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/3d-view": {
@@ -19121,7 +19126,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -19137,19 +19142,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -19164,7 +19169,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -19182,7 +19187,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -25806,9 +25811,10 @@
       }
     },
     "node_modules/react-bootstrap": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.6.7.tgz",
-      "integrity": "sha512-IzCYXuLSKDEjGFglbFWk0/iHmdhdcJzTmtS6lXxc0kaNFx2PFgrQf5jKnx5sarF2tiXh9Tgx3pSt3pdK7YwkMA==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.6.8.tgz",
+      "integrity": "sha512-yD6uN78XlFOkETQp6GRuVe0s5509x3XYx8PfPbirwFTYCj5/RfmSs9YZGCwkUrhZNFzj7tZPdpb+3k50mK1E4g==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.14.0",
@@ -25835,24 +25841,27 @@
       }
     },
     "node_modules/react-bootstrap/node_modules/@types/react-transition-group": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.9.tgz",
-      "integrity": "sha512-ZVNmWumUIh5NhH8aMD9CR2hdW0fNuYInlocZHaZ+dgk/1K49j1w/HoAuK1ki+pgscQrOFRTlXeoURtuzEkV3dg==",
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.11.tgz",
+      "integrity": "sha512-RM05tAniPZ5DZPzzNFP+DmrcOdD0efDUxMy3145oljWSl3x9ZV5vhme98gTxFrj2lhXvmGNnUiuDyJgY9IKkNA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
     },
     "node_modules/react-bootstrap/node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/react-bootstrap/node_modules/dom-helpers": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
       "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.8.7",
@@ -25863,6 +25872,7 @@
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
       "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.5.5",
@@ -25873,6 +25883,28 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-button": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/react-button/-/react-button-1.2.1.tgz",
+      "integrity": "sha512-5n1ZiFE3oTV9LAnBPSv7+2cFcj2QVB/2xHGkodJH8bKibU/NYAV3GWuS1Awduit91kdctv/Rqws/bez02rj4FA==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^2.0.0",
+        "react-style-normalizer": "^1.1.5"
+      },
+      "peerDependencies": {
+        "react": ">=0.12.0"
+      }
+    },
+    "node_modules/react-button/node_modules/object-assign": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+      "integrity": "sha512-CdsOUYIh5wIiozhJ3rLQgmUTgcyzFwZZrqhkKhODMoGtPKM+wt0h0CNIoauJWMsS9822EdzPsF/6mb4nLvPN5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react-color": {
@@ -26024,6 +26056,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.2.1.tgz",
       "integrity": "sha512-GLLSOLWr21CqtJn8geSwQfoJufdt3mfdsnIiQswouuQ2MMPns+ihZklxvsTDKD3cR2tF8ELbi5xUsvqVhR6WvA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.13.8",
@@ -26041,15 +26074,17 @@
       }
     },
     "node_modules/react-overlays/node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/react-overlays/node_modules/dom-helpers": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
       "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.8.7",
@@ -26104,6 +26139,12 @@
       "dependencies": {
         "isarray": "0.0.1"
       }
+    },
+    "node_modules/react-style-normalizer": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/react-style-normalizer/-/react-style-normalizer-1.2.8.tgz",
+      "integrity": "sha512-smaq27S/Gfj08wsNvLuuA03SKr6K44BVZFyqQEBFyqlQ9MSUi6ydRoBfNcZQeIUNkjRxi1W97sNNs54zFqGC2Q==",
+      "license": "MIT"
     },
     "node_modules/react-transition-group": {
       "version": "2.9.0",
@@ -26369,6 +26410,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2"

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "react": "^16.13.1",
     "react-addons": "^0.9.1-deprecated",
     "react-autocomplete": "^1.8.1",
+    "react-button": "^1.2.1",
     "react-color": "^2.19.3",
     "react-datetime": "^2.16.3",
     "react-dom": "^16.13.1",

--- a/public/js/lib/leaflet.tilelayer.wmts/leaflet.tilelayer.wmts.src.js
+++ b/public/js/lib/leaflet.tilelayer.wmts/leaflet.tilelayer.wmts.src.js
@@ -1,0 +1,57 @@
+(function () {
+    'use strict';
+    
+  L.TileLayer.WMTS = L.TileLayer.extend({
+    defaultWmtsParams: {
+      service: "WMTS",
+      request: "GetTile",
+      version: "1.0.0",
+      layer: "",
+      style: "default",
+      tileMatrixSet: "",
+      format: "image/jpeg",
+    },
+    initialize: function (url, options) {
+      this._url = url;
+  
+      const wmtsParams = L.extend({}, this.defaultWmtsParams);
+  
+      // all keys that are not TileLayer options go to WMS params
+      for (const i in options) {
+        if (!(i in this.options)) {
+          wmtsParams[i] = options[i];
+        }
+      }
+  
+      options = L.setOptions(this, options);
+  
+      const realRetina = options.detectRetina && retina ? 2 : 1;
+      const tileSize = this.getTileSize();
+      wmtsParams.width = tileSize.x * realRetina;
+      wmtsParams.height = tileSize.y * realRetina;
+  
+      this.wmtsParams = wmtsParams;
+    },
+    getTileUrl: function (coords) {
+      this.wmtsParams.tileMatrix = this._tileZoom.toString();
+  
+      const url = L.Util.template(this._url, { s: this._getSubdomain(coords) });
+  
+      const params = { ...this.wmtsParams, tileRow: coords.y, tileCol: coords.x };
+  
+      return  url + L.Util.getParamString(params);
+    },
+    setParams: function (params, noRedraw) {
+      L.extend(this.wmtsParams, params);
+      if (!noRedraw) {
+        this.redraw();
+      }
+      return this;
+    },
+  });
+  
+  L.tileLayer.wmts = function (url, options) {
+    return new L.TileLayer.WMTS(url, options);
+  };
+  
+  }());


### PR DESCRIPTION
When initializing project with `npm install --legacy-peer-deps` i get react-button missing. when setting up a wmts baselayer, i get wmts missing. so this PR:

* Added react-button, because it was missing during grunt
* Added leaflet wmts file manually, was missing in lib for wmts support - but mentioned in grunt