### PR TITLE
fix non-toggeling subgroups

### DIFF
--- a/browser/modules/layerTree/index.js
+++ b/browser/modules/layerTree/index.js
@@ -4150,7 +4150,7 @@ module.exports = {
                     }
                     return false;
                 }).length;
-                activeLayersInSubGroups += activeLayers.filter(e => JSON.parse(metaDataKeys[layerTreeUtils.stripPrefix(e)].meta)?.vidi_sub_group.match(re) && metaDataKeys[layerTreeUtils.stripPrefix(e)].layergroup === layerGroup).length;
+                activeLayersInSubGroups += activeLayers.filter(e => JSON.parse(metaDataKeys[layerTreeUtils.stripPrefix(e)].meta)?.vidi_sub_group?.match(re) && metaDataKeys[layerTreeUtils.stripPrefix(e)].layergroup === layerGroup).length;
                 const searchPath = `[data-gc2-group-id="${layerGroup}"]` + ' ' + split.map(e => `[data-gc2-subgroup-id="${e}"]`).join(' ') + ` [data-gc2-subgroup-name="${split[split.length - 1]}"]`;
                 const el = document.querySelector(searchPath);
                 if (el) {


### PR DESCRIPTION
this comically small pr fixes an issue where subgroups in groups were not toggled on when the entire group is toggled. 

layertree throws an error like this:
![billede](https://github.com/user-attachments/assets/fca862b8-bedc-4956-9c28-802c263485eb)
