### PR TITLE
Fix: initialize colorpicker in advanced

### DIFF
--- a/browser/modules/search/danish.js
+++ b/browser/modules/search/danish.js
@@ -117,9 +117,10 @@ module.exports = {
                             <label for="search-colorpicker-input" class="col-md-3 control-label">${__('Color')}</label>
                             <div id="search-colorpicker" class="input-group colorpicker-component col-md-10">
                                 <input id="search-colorpicker-input" name="search-colorpicker-input"
-                                       type="text" value="#ff0000" class="form-control"
+                                       type="color" value="#ff0000" class="form-control form-control-color"
                                        style="margin-left: 15px;"/>
                                 <span class="input-group-addon"><i style="margin-left: 10px;"/></span>
+
                             </div>
                         </div>
                     </div>

--- a/browser/modules/search/danish.js
+++ b/browser/modules/search/danish.js
@@ -127,10 +127,14 @@ module.exports = {
                 </div>`;
 
         if (advanced) {
-            $("#place-search").append(colorPicker)
-            $("#search-colorpicker").colorpicker({
-                container: $("#search-colorpicker")
-            });
+            try {
+                $("#place-search").append(colorPicker)
+                $("#search-colorpicker").colorpicker({
+                    container: $("#search-colorpicker")
+                });
+            } catch (e) {
+                console.error(e)
+            }
         }
 
         // Set max zoom then zooming on target


### PR DESCRIPTION
Starting vidi with the config:

```
"searchConfig": {
        "advanced": true
    },
```

yields an error: `Could not perform application initialization $(...).colorpicker is not a function TypeError: $(...).colorpicker is not a function`

I fixed it by adopting the DOM from `draw.js`