### PR TITLE
DF: Add redirection option

### DIFF
--- a/controllers/df.js
+++ b/controllers/df.js
@@ -7,11 +7,12 @@
 const express = require('express');
 const request = require('request');
 const router = express.Router();
+const config = require('../config/config.js');
 
 router.get('/api/datafordeler/*', (req, response) => {
-    const userName = require('../config/config.js')?.df?.datafordeler?.username;
-    const pwd = require('../config/config.js')?.df?.datafordeler?.password;
-    const token = require('../config/config.js')?.df?.datafordeler?.token;
+    const userName = config?.df?.datafordeler?.username;
+    const pwd = config?.df?.datafordeler?.password;
+    const token = config?.df?.datafordeler?.token;
     const host = 'https://services.datafordeler.dk';
     let creds = token ? `&token=${token}` : `&username=${userName}&password=${pwd}`;
     let requestURL = host + decodeURIComponent(req.url.substr(17)) + creds;
@@ -19,9 +20,9 @@ router.get('/api/datafordeler/*', (req, response) => {
     get(requestURL, response);
 });
 router.get('/api/dataforsyningen/*', (req, response) => {
-    const userName = require('../config/config.js')?.df?.dataforsyningen?.username;
-    const pwd = require('../config/config.js')?.df?.dataforsyningen?.password;
-    const token = require('../config/config.js')?.df?.dataforsyningen?.token;
+    const userName = config?.df?.dataforsyningen?.username;
+    const pwd = config?.df?.dataforsyningen?.password;
+    const token = config?.df?.dataforsyningen?.token;
     const host = 'https://api.dataforsyningen.dk';
     let creds = token ? `&token=${token}` : `&username=${userName}&password=${pwd}`;
     let requestURL = host + decodeURIComponent(req.url.substr(20)) + creds;
@@ -30,11 +31,17 @@ router.get('/api/dataforsyningen/*', (req, response) => {
 });
 
 const get = (url, res) => {
-    //console.log(url);
-    let options = {
-        method: 'GET',
-        uri: url
-    };
-    request(options).on('error', (e) => console.error(e)).pipe(res);
+    // Let the user decide if they want to redirect or wait for the response
+    if (config?.df?.redirect) {
+        res.redirect(url);
+    
+    // or wait for the response
+    } else {
+        let options = {
+            method: 'GET',
+            uri: url
+        };
+        request(options).on('error', (e) => console.error(e)).pipe(res);
+    }
 }
 module.exports = router;

--- a/docs/pages/standard/90_build_configuration.rst
+++ b/docs/pages/standard/90_build_configuration.rst
@@ -102,6 +102,8 @@ df
 
 Til WMS baggrundskort fra Datafordeler og Dataforsyningen kan der anvendes en proxy, som til dels fixer et problem med Datafordeler og til dels kan forsyne kaldene med brugernavn/kodeord eller token, så disse ikke bliver eksponeret til Vidi brugerne.
 
+* ``redirect`` Angiver om modulet skal omstille kaldene til Datafordeler og Dataforsyningen, eller klienten skal vente på svaret fra services. default er false.
+
 Det er kun nødvendig at angive enten username/password eller token. Token har forrang hvis begge er angivet:
 
 .. code-block:: json
@@ -116,7 +118,8 @@ Det er kun nødvendig at angive enten username/password eller token. Token har f
             "username": "....",
             "password": "....",
             "token": "...."
-        }
+        },
+        "redirect": false
     }
 
 Se i Kørselskonfigurationen :ref:`configjs_baselayers` hvordan WMS'er fra Datafordeler og Dataforsyningen kan anvendes


### PR DESCRIPTION
Added an option to redirect the calls though df to the source, rather than hold up the node-process trying to wait for a reply.

We have used this logic for some time with good results. As we host from eu-north, the calls to made an unnecessary roundtrip.

* added option
* added documentation
* refactored df.js to simplify config-loading.