### PR TITLE
Feature: Group Baselayers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [CalVer](https://calver.org/).
 
+## Unreleased
+
+### Added
+
+- Added configuration for grouping baselayers:
+
+```json
+"baseLayerGroups": [
+        {
+            "groupName": "Hexagon DDO ortofoto",
+            "layers": [
+                "DK-DDOland2022_125mm_UTM32ETRS89",
+                ...,
+                ...
+            ]
+        },
+        {
+            "groupName": "GeoDanmark ortofoto",
+            "layers": [
+                "ortofoto_foraar_temp_DF",
+                "ortofoto_foraar_2023",
+                ...,
+                ...
+            ]
+        }
+    ]
+```
+
 ## [2025.3.1] - 2025-10-3
 
 ### Added

--- a/browser/modules/baseLayer.js
+++ b/browser/modules/baseLayer.js
@@ -282,9 +282,9 @@ module.exports = module.exports = {
         }
         return false;
     },
-    buildLayerHtmlNode(layerId, layerName, tooltip, displayInfo, abstract) {
+    buildLayerHtmlNode(layerId, layerName, tooltip, displayInfo, abstract, ingroup=false) {
         const sideBySideLayerControl = _self.getSideBySideLayerControl(layerId);
-        return `<li class="list-group-item js-base-layer-control d-flex align-items-center">
+        return `<li class="list-group-item js-base-layer-control d-flex align-items-center${ingroup ? `px-3 border-start-0 border-end-0` : ``}">
                     <div class="d-flex align-items-center gap-1 me-auto">
                         <div class='base-layer-item' data-gc2-base-id='${layerId}'>
                             <input type='radio' class="form-check-input" name='baselayers' value='${layerId}' ${layerId === activeBaseLayer ? `checked=""` : ``}> 
@@ -312,7 +312,7 @@ module.exports = module.exports = {
     },
     buildLayerHtmlGroupStart(groupName, open) {
         const isOpen = open ? "open='open'" : ''
-        return `<li class="list-group-item js-base-layer-control d-flex align-items-center"> <details ${isOpen}><summary>${groupName}</summary>`;
+        return `<li class="list-group-item js-base-layer-control align-items-center p-0"> <details ${isOpen}><summary class="py-2 px-3">${groupName}</summary>`;
     },
     buildLayerHtmlGroupEnd() {
         return '</details></li>';
@@ -335,7 +335,7 @@ module.exports = module.exports = {
 
                 let displayInfo = (bl.abstract ? `visible` : `hidden`);
                 let tooltip = (bl.abstract ? $(bl.abstract).text() : ``);
-                result += _self.buildLayerHtmlNode(bl.id, bl.name, tooltip, displayInfo, bl.abstract)
+                result += _self.buildLayerHtmlNode(bl.id, bl.name, tooltip, displayInfo, bl.abstract, true);
             }
             result += _self.buildLayerHtmlGroupEnd();
         }

--- a/browser/modules/baseLayer.js
+++ b/browser/modules/baseLayer.js
@@ -249,45 +249,42 @@ module.exports = module.exports = {
         _self.drawBaseLayersControl();
     },
 
-    drawBaseLayersControl: () => {
-        return new Promise((resolve, reject) => {
-            // Resetting the side-by-side mode
-            currentTwoLayersAtOnceMode = TWO_LAYERS_AT_ONCE_MODES[defaultMode - 1];
+    // get the baseLayerGroup object.
+    getBaseLayerGruop() {
+        return window.vidiConfig.baseLayerGroups;
+    },
+    // true: baseLayerGroups exists
+    hasBaseLayerGroup() {
+        return _self.getBaseLayerGruop() !== undefined;
+    },
 
-            // Delete current layers
-            $(`.js-base-layer-control`).remove();
-            baseLayers = [];
 
-            // Add base layers controls
-            let appendedCode = ``;
-            for (var i = 0; i < window.setBaseLayers.length; i = i + 1) {
-                let bl = window.setBaseLayers[i];
 
-                let layerId = false;
-                let layerName = false;
-                if (typeof bl.type !== "undefined" && bl.type === "MVT") {
-                    baseLayers.push(bl.id);
-                    layerId = bl.id;
-                    layerName = bl.name;
-                } else if (typeof window.setBaseLayers[i].restrictTo === "undefined"
-                    || window.setBaseLayers[i].restrictTo.filter((n) => {
-                        return schemas.indexOf(n) !== -1;
-                    }).length > 0) {
-                    baseLayers.push(window.setBaseLayers[i].id);
-                    layerId = window.setBaseLayers[i].id;
-                    layerName = window.setBaseLayers[i].name;
-                }
-
-                let sideBySideLayerControl = ``;
-                if (twoLayersAtOnceEnabled) {
-                    sideBySideLayerControl = `<div class='base-layer-item' data-gc2-side-by-side-base-id='${layerId}' style='float: left;'>
-                            <input type='radio' class="form-check-input" name='side-by-side-baselayers' value='${layerId}' ${layerId === activeTwoLayersModeLayer ? `checked=""` : ``}>
-                    </div>`;
-                }
-
-                let displayInfo = (bl.abstract ? `visible` : `hidden`);
-                let tooltip = (bl.abstract ? $(bl.abstract).text() : ``);
-                appendedCode += `<li class="list-group-item js-base-layer-control d-flex align-items-center">
+    // returns a array of groupName from 
+    baseLayerGroupNames() {
+        if (!_self.hasBaseLayerGroup())
+            return [];
+        return _self.getBaseLayerGruop().map(group => group.groupName);
+    },
+    // returns array of layerIds for a group 
+    baseLayerGetLayersFromGroup(groupName) {
+        const group = _self.getBaseLayerGruop().find(group => group.groupName === groupName);
+        return group ? group.layers : null;
+    },
+    //  true: layerId is in a baseLayerGroup
+    baseLayerIsInGroup(layerId) {
+        if (!_self.hasBaseLayerGroup())
+            return false;
+        for (const group of _self.getBaseLayerGruop()) {
+            if (group.layers.includes(layerId)) {
+                return true; //group.groupName;
+            }
+        }
+        return false;
+    },
+    buildLayerHtmlNode(layerId, layerName, tooltip, displayInfo, abstract) {
+        const sideBySideLayerControl = _self.getSideBySideLayerControl(layerId);
+        return `<li class="list-group-item js-base-layer-control d-flex align-items-center">
                     <div class="d-flex align-items-center gap-1 me-auto">
                         <div class='base-layer-item' data-gc2-base-id='${layerId}'>
                             <input type='radio' class="form-check-input" name='baselayers' value='${layerId}' ${layerId === activeBaseLayer ? `checked=""` : ``}> 
@@ -302,12 +299,96 @@ module.exports = module.exports = {
                             title="${tooltip}"
                             style="visibility: ${displayInfo};"
                             data-baselayer-name="${layerName}"
-                            data-baselayer-info="${bl.abstract}"
-                            class="info-label btn btn-sm btn-outline-secondary"><i class="bi bi-info-square pe-none"></i></button>
+                            data-baselayer-info="${abstract}"
+                            class="info-label btn btn-sm btn-light"><i class="bi bi-info-square pe-none"></i></button>
                     </div>
                 </li>`;
 
+    },
+
+    getBaseLayerById(layerId) {
+        const bl = window.setBaseLayers.find(bl => bl.id === layerId);
+        return bl;
+    },
+    buildLayerHtmlGroupStart(groupName, open) {
+        const isOpen = open ? "open='open'" : ''
+        return `<li class="list-group-item js-base-layer-control d-flex align-items-center"> <details ${isOpen}><summary>${groupName}</summary>`;
+    },
+    buildLayerHtmlGroupEnd() {
+        return '</details></li>';
+    },
+
+    buildLayerHtmlInGroup() {
+
+        let result = '';
+
+        for (const groupName of _self.baseLayerGroupNames()) {
+            const bls = _self.baseLayerGetLayersFromGroup(groupName);
+            if (!bls)
+                continue;
+            const isOpen = bls.includes(activeBaseLayer);
+            result += _self.buildLayerHtmlGroupStart(groupName, isOpen);
+
+            for (const layerId of bls) {
+                const bl = _self.getBaseLayerById(layerId);
+                if (!bl) continue;
+
+                let displayInfo = (bl.abstract ? `visible` : `hidden`);
+                let tooltip = (bl.abstract ? $(bl.abstract).text() : ``);
+                result += _self.buildLayerHtmlNode(bl.id, bl.name, tooltip, displayInfo, bl.abstract)
             }
+            result += _self.buildLayerHtmlGroupEnd();
+        }
+        return result;
+    },
+
+    getSideBySideLayerControl(layerId) {
+        const valueContent = layerId === activeTwoLayersModeLayer ? `checked=""` : ``;
+        return (twoLayersAtOnceEnabled) ?
+            `<div class='base-layer-item' data-gc2-side-by-side-base-id='${layerId}' style='float: left;'>
+                    <input type='radio' class="form-check-input" name='side-by-side-baselayers' value='${layerId}' ${valueContent}>
+            </div>`:
+            ``;
+    },
+
+    drawBaseLayersControl: () => {
+        return new Promise((resolve, reject) => {
+            // Resetting the side-by-side mode
+            currentTwoLayersAtOnceMode = TWO_LAYERS_AT_ONCE_MODES[defaultMode - 1];
+
+            // Delete current layers
+            $(`.js-base-layer-control`).remove();
+            baseLayers = [];
+
+            // Add base layers controls, not in group
+            let appendedCode = ``;
+            for (const bl of window.setBaseLayers) {
+
+                 
+                let layerId = false;
+                let layerName = false;
+                if (typeof bl.type !== "undefined" && bl.type === "XYZ") {
+                    baseLayers.push(bl.id);
+                    layerId = bl.id;
+                    layerName = bl.name;
+                } else if (typeof bl.restrictTo === "undefined"
+                    || bl.restrictTo.filter((n) => {
+                        return schemas.indexOf(n) !== -1;
+                    }).length > 0) {
+                    baseLayers.push(bl.id);
+                    layerId = bl.id;
+                    layerName = bl.name;
+                }
+                if (_self.baseLayerIsInGroup(layerId)) {
+                    continue;
+                }
+
+                let displayInfo = (bl.abstract ? `visible` : `hidden`);
+                let tooltip = (bl.abstract ? $(bl.abstract).text() : ``);
+                appendedCode += _self.buildLayerHtmlNode(layerId, layerName, tooltip, displayInfo, bl.abstract);
+
+            }
+            appendedCode += _self.buildLayerHtmlInGroup();
 
             const disableInputs = () => {
                 // Disabling inputs of side-by-side base layers

--- a/browser/modules/init.js
+++ b/browser/modules/init.js
@@ -49,6 +49,7 @@ module.exports = {
         const defaults = {
             schemata: [],
             baseLayers: [],
+            baseLayerGroups: [],
             autoPanPopup: false,
             crossMultiSelect: false,
             brandName: '',

--- a/docs/pages/standard/91_run_configuration.rst
+++ b/docs/pages/standard/91_run_configuration.rst
@@ -337,6 +337,57 @@ Vidi sørger så for at tilføje bruger-infomationen og tilrette URL.
 .. note::
     HERE, Bing og Google Maps kræver API nøgle opsat i GC2. Google Maps fungerer på en anden måde end andre lag og langt fra optimalt. Fx kan man ikke printe Google Maps.
 
+.. _configjs_baseLayergroups:
+
+baseLayerGroups
+*****************************************************************
+
+Det er muligt at gruppere flere baggrundskort i en gruppe. Grupperne kan vises indledningsvis i en skuffe. 
+
+For at gruppere baggrundskortene, angives strukturen i ``baseLayerGroups``. De enkelte baggrundskort angives med samme id som beskrevet i :ref:`configjs_baselayers`.
+
+.. code-block:: json
+
+    "baseLayerGroups": [
+        {
+            "groupName": "Hexagon DDO ortofoto 2022-1995 + 1954",
+            "layers": [
+                "DK-DDOland2022_125mm_UTM32ETRS89",
+                "DK-DDOland2020_125mm_UTM32ETRS89",
+                "DK_HxIP-ORTO2018_30cm_UTM32ETRS89",
+                "DK-DDOland2016_125mm_UTM32ETRS89",
+                "DK-DDOland2015_25CM_UTM32ETRS89",
+                "DK-DDOland2014_12CM_UTM32ETRS89",
+                "DK-DDObasis2013_25cm_UTM32ETRS89",
+                "DK-DDOland2012_125mm_UTM32ETRS89",
+                "DK-DDOland2010_125mm_UTM32ETRS89",
+                "DK-DDOland2008_125mm_UTM32ETRS89",
+                "DK-DDOland2006_25cm_UTM32ETRS89",
+                "DK-DDOland2004_25cm_UTM32ETRS89",
+                "DK-DDOland2002_40cm_UTM32ETRS89",
+                "DK-DDOland1999_40cm_UTM32ETRS89",
+                "DK-DDOland1995_80cm_UTM32ETRS89",
+                "DK-DDOland1954_25cm_UTM32ETRS89"
+            ]
+        },
+        {
+            "groupName": "GeoDanmark forår ortofoto 2023-2015 + quick-orto",
+            "layers": [
+                "ortofoto_foraar_temp_DF",
+                "ortofoto_foraar_2023",
+                "ortofoto_foraar_2022",
+                "ortofoto_foraar_2021",
+                "ortofoto_foraar_2020",
+                "ortofoto_foraar_2019",
+                "ortofoto_foraar_2018",
+                "ortofoto_foraar_2017",
+                "ortofoto_foraar_2016",
+                "ortofoto_foraar_2015"
+            ]
+        }
+    ]
+
+
 .. _configjs_aboutbox:
 
 aboutBox


### PR DESCRIPTION
Add configuration for grouping baselayers. The feature is great for saving UI-space in configurations where a lot of similar layers are available to the end user.

![baseLayerGroups](https://github.com/user-attachments/assets/71f4584c-8158-4dde-a958-46d363cb428c)

The implementation is largely written by @GunnarJulJensen. 

* Added feature
* adjusted UI to fit into existing
* add documentation