### PR TITLE
Fix: set placeholderText

### DIFF
--- a/browser/modules/search/danish.js
+++ b/browser/modules/search/danish.js
@@ -89,18 +89,18 @@ module.exports = {
         let placeholder = window.vidiConfig?.searchConfig?.placeholderText;
         if (placeholder) {
             searchTxt = placeholder;
-            $(".custom-search.tt-input").attr("placeholder",
+            $(".custom-search.typeahead.form-control:not(.tt-hint)").attr("placeholder",
                 searchTxt
             );
         } else {
             searchTxt = "Adresse, matr. nr.";
             if (sfeSearchActive) {
-                $(".custom-search.tt-input").attr("placeholder",
+                $(".custom-search.typeahead.form-control:not(.tt-hint)").attr("placeholder",
                     searchTxt
                     + (esrSearchActive ? ", ESR nr. " : "")
                     + " eller SFE nr.");
             } else if (esrSearchActive) {
-                $(".custom-search.tt-input").attr("placeholder",
+                $(".custom-search.typeahead.form-control:not(.tt-hint)").attr("placeholder",
                     searchTxt + " eller ESR nr.");
             }
         }
@@ -1201,7 +1201,7 @@ module.exports = {
             fromVarsIsDone = true;
         }
         $(el).typeahead({
-            highlight: false
+            highlight: false,
         }, ...standardSearches);
         $(el).bind('typeahead:selected', function (obj, datum, name) {
             if ((type1 === "adresse" && name === "adresse") || (type2 === "jordstykke" && name === "matrikel")

--- a/browser/modules/search/danish.js
+++ b/browser/modules/search/danish.js
@@ -1201,7 +1201,7 @@ module.exports = {
             fromVarsIsDone = true;
         }
         $(el).typeahead({
-            highlight: false,
+            highlight: false
         }, ...standardSearches);
         $(el).bind('typeahead:selected', function (obj, datum, name) {
             if ((type1 === "adresse" && name === "adresse") || (type2 === "jordstykke" && name === "matrikel")


### PR DESCRIPTION
When setting the `searchConfig.placeholderText` in the config, the users expect the placeholder value to change, but this only works with the `conflictSearch`-extension enabled. This PR only fixes the problem for `danish.js`-search module - I have not looked in to the other one.

The issue seems to be a race-condition;

The first pass of the code correctly picks up the `searchConfig.placeholderText` and attempts to set the value - however, since typeahead is not yet initialized, the class does not exist. 

The element available at the first evaluation looks like this:

``` html
<input class="custom-search typeahead form-control" type="text" placeholder="Adresse eller matrikelnr.">
```

Since we set the `placeholder`-value for typeahead in the DOM, we need it changed here.

Once typeahead is initialized, the class exists on the element like this:

``` html
<input class="custom-search typeahead form-control tt-input" type="text" placeholder="Adresse eller matrikelnr." autocomplete="off" spellcheck="false" dir="auto" style="position: relative; vertical-align: top; background-color: transparent;">
```

Which explains why the `searchConfig.placeholderText` is correctly set once the `conflictSearch`-extension re-initializes `danish.js`

I suspect the other logic regarding `sfeSearchActive` and `esrSearchActive` has also failed for some time. 

This PR targets the DOM that exists before initialization, and ignores the `tt-hint` element. Otherwise we get nasty ghosting.
