### PR TITLE
Change: Get smallest print scale from config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ and this project adheres to [CalVer](https://calver.org/).
 
 - Better handling of vector layers in `activeLayers`. If `activeLayers` only had vector layers, they wouldn't be activated.
 
+### Changed
+
+- The minimum scale available for print has been changed from a fixed `200` to the lowest value of `config.print.scales`.
+
 ## [2025.3.1] - 2025-10-3
 
 ### Added

--- a/browser/i18n/da_DK.js
+++ b/browser/i18n/da_DK.js
@@ -182,7 +182,7 @@ module.exports = {
         "Ok": "Ok",
         "Apply default style settings for this drawing?": "Anvend standard stilindstillinger til denne tegning?",
 
-        "Not a valid scale. Must be over 200.": "Ikke en gyldig målestok. Den skal være over 200.",
+        "Not a valid scale. Must be over ": "Ikke en gyldig målestok. Den skal være over ",
 
         "Languages": "Sprog",
 

--- a/browser/i18n/en_US.js
+++ b/browser/i18n/en_US.js
@@ -182,7 +182,7 @@ module.exports = {
         "Ok": "Ok",
         "Apply default style settings for this drawing?": "Apply default style settings for this drawing?",
 
-        "Not a valid scale. Must be over 200.": "Not a valid scale. Must be over 200.",
+        "Not a valid scale. Must be over ": "Not a valid scale. Must be over ",
 
         "Languages": "Languages",
 

--- a/browser/modules/print.js
+++ b/browser/modules/print.js
@@ -41,6 +41,7 @@ var alreadySetFromState = false;
 var setState = true;
 var paramsFromDb;
 let scaleFromForm = false;
+let min_scale = scales.length > 0 ? Math.min(...scales) : 200;
 
 import dayjs from 'dayjs';
 import advancedFormat from "dayjs/plugin/advancedFormat";
@@ -460,8 +461,8 @@ module.exports = {
 
         var layerQueryDraw = [], layerQueryResult = [], layerQueryBuffer = [], layerPrint = [], e, parr,
             configFile = null;
-        if (scale && (isNaN(scale) || scale < 200)) {
-            alert(__("Not a valid scale. Must be over 200."));
+        if (scale && (isNaN(scale) || scale < min_scale)) {
+            alert(__("Not a valid scale. Must be over ") + min_scale + ".");
             return false;
         }
         backboneEvents.get().trigger("start:print");


### PR DESCRIPTION
This PR lets the user decide the smallest print scale, and keeps the user from setting a lower value in `config.print.scales` - fallback to `200`.

Contains minor changes to i18, because the value is dynamic.