### PR TITLE
Expose seletedDrawing from draw module

### DIFF
--- a/browser/modules/draw.js
+++ b/browser/modules/draw.js
@@ -439,6 +439,13 @@ module.exports = {
     },
 
     /**
+     * Returns the selected drawing
+     */
+    getSelectedDrawing: () => {
+        return selectedDrawing;
+    },
+
+    /**
      * Applies externally provided state
      */
     applyState: (newState) => {


### PR DESCRIPTION
When writing custom extensions for Vidi, one of the key functionalities is usually interacting with geometry defined in the draw module. 

This proposed changes is a non-invasive way of getting the currently selected drawing other places in the application. Getting all of the drawings is still possible using `getDrawItems`.