### PR TITLE
Fix: _rel values in infobox and table

### DIFF
--- a/browser/modules/sqlQuery.js
+++ b/browser/modules/sqlQuery.js
@@ -9,7 +9,6 @@
 import {LAYER, MAP_RESOLUTIONS, SYSTEM_FIELD_PREFIX} from './layerTree/constants';
 import {GEOJSON_PRECISION, MIME_TYPES_APPS, MIME_TYPES_IMAGES} from './constants';
 import dayjs from 'dayjs';
-import { PropertyValue } from 'maplibre-gl';
 
 const layerTreeUtils = require('./layerTree/utils');
 

--- a/browser/modules/sqlQuery.js
+++ b/browser/modules/sqlQuery.js
@@ -742,6 +742,7 @@ module.exports = {
                     });
                 } else {
                     $.each(sortObject(fieldConf), (name, property) => {
+                        let metaDataForField = metaDataKeys[keyWithOutPrefix].fields[property.key] ? metaDataKeys[keyWithOutPrefix].fields[property.key] : null;
                         if (property.value.querable) {
                             let value = feature.properties[property.key];
                             // Only set field template if property is set or not empty string OR if 'replaceNull' helper is used, which will replace nulls
@@ -834,6 +835,15 @@ module.exports = {
                                     }
                                 }
                             }
+                            // If metaDataForField.restrictions has an array, we get the related values
+                            else if (metaDataForField && metaDataForField.restriction && Array.isArray(metaDataForField.restriction)) {
+                                let restrictions = metaDataForField.restriction;
+                                let restriction = restrictions.find(restriction => restriction.value === value);
+                                if (restriction) {
+                                    value = restriction.alias;
+                                }
+                            }
+                            
                             fields.push({title: property.value.alias || property.key, value});
                             fieldLabel = (property.value.alias !== null && property.value.alias !== "") ? property.value.alias : property.key;
                             if (feature.properties[property.key] !== undefined) {

--- a/browser/modules/sqlQuery.js
+++ b/browser/modules/sqlQuery.js
@@ -9,6 +9,7 @@
 import {LAYER, MAP_RESOLUTIONS, SYSTEM_FIELD_PREFIX} from './layerTree/constants';
 import {GEOJSON_PRECISION, MIME_TYPES_APPS, MIME_TYPES_IMAGES} from './constants';
 import dayjs from 'dayjs';
+import { PropertyValue } from 'maplibre-gl';
 
 const layerTreeUtils = require('./layerTree/utils');
 
@@ -837,17 +838,16 @@ module.exports = {
                             }
                             // If metaDataForField.restrictions has an array, we get the related values
                             else if (metaDataForField && metaDataForField.restriction && Array.isArray(metaDataForField.restriction)) {
-                                let restrictions = metaDataForField.restriction;
-                                let restriction = restrictions.find(restriction => restriction.value === value);
+                                property.restrictions = metaDataForField.restriction;
+                                let restriction = property.restrictions.find(restriction => restriction.value === value);
                                 if (restriction) {
                                     value = restriction.alias;
                                 }
                             }
-                            
                             fields.push({title: property.value.alias || property.key, value});
                             fieldLabel = (property.value.alias !== null && property.value.alias !== "") ? property.value.alias : property.key;
                             if (feature.properties[property.key] !== undefined) {
-                                out.push([property.key, property.value.sort_id, fieldLabel, property.value.link, property.value.template, property.value.content]);
+                                out.push([property.key, property.value.sort_id, fieldLabel, property.value.link, property.value.template, property.value.content, property.restrictions || null]);
                             }
                         }
                     });
@@ -869,6 +869,7 @@ module.exports = {
                             link: property[3],
                             template: property[4],
                             content: property[5],
+                            restrictions: property[6]
                         })
                     });
                     first = false;

--- a/public/js/gc2/gc2table.js
+++ b/public/js/gc2/gc2table.js
@@ -450,6 +450,12 @@ var gc2table = (function () {
                             layerClone[n] = `<div style="cursor: pointer" onclick="window.open().document.body.innerHTML = '<img src=\\'${layerClone[n]}\\' />';">
                                         <img style='width:25px' src='${layerClone[n]}'/>
                                      </div>`
+                        } else if (k.dataIndex === n && (k?.restrictions && (layerClone[n] && layerClone[n] !== ''))) {
+                            let restriction = k.restrictions.find(restriction => restriction.value === layerClone[n]);
+                            if (restriction) {
+                                // replace value with alias
+                                layerClone[n] = restriction.alias;
+                            }
                         }
                     });
                 });


### PR DESCRIPTION
This PR replaces the values in the info box with the restricted value, without needing a view to handle the translation.

If a layer is setup with _rel in properties in GC2:
`{'_rel':'ledningsplan_fjv.d_driftstraekning', '_value':'code', '_text':'description'}`

the _text value will be inserted into the infoboxes

![image](https://github.com/user-attachments/assets/d66cc806-1572-4257-94d1-1adc3f55b225)
![image](https://github.com/user-attachments/assets/50fe5b2e-bd5a-46ce-a45c-3f56bd97bdf6)

When merging this PR - please squash.