### PR TITLE
Fix: ConflictSearch - Error on long reports

### DIFF
--- a/extensions/conflictSearch/browser/reportRender.js
+++ b/extensions/conflictSearch/browser/reportRender.js
@@ -46,7 +46,8 @@ module.exports = {
             tr = $("<tr class='print-report-group-heading' style='border-top: 1px solid; '><td style='padding-bottom: 4px;'><h3>" + groups[x] + "</h3></td></tr>");
             table.append(tr);
             let count = 0;
-            e.hits.forEach((v, i) => {
+            Object.keys(e.hits).forEach((v, i) => {
+                v = e.hits[v];
                 let metaData = v.meta;
                 if (metaData.layergroup === groups[x]) {
                     let flag = false;

--- a/extensions/conflictSearch/browser/reportRenderAlt.js
+++ b/extensions/conflictSearch/browser/reportRenderAlt.js
@@ -45,7 +45,8 @@ module.exports = {
             tr = $("<tr class='print-report-group-heading' style='border-top: 1px solid; '><td style='padding-bottom: 4px;'><h3>" + groups[x] + "</h3></td></tr>");
             table.append(tr);
             let count = 0;
-            e.hits.forEach((v, i) => {
+            Object.keys(e.hits).forEach((v, i) => {
+                v = e.hits[v];
                 let metaData = v.meta;
                 if (metaData.layergroup === groups[x]) {
                     if (v.hits > 0) {


### PR DESCRIPTION
The current implementation fails with an error like:

![image](https://github.com/user-attachments/assets/a6a56340-753a-45a7-aabb-b912c663a9ee)

I have corrected the loop in a non-invasive way, and copied the fix to `reportRenderAlt.js`