### PR TITLE
Fix: PNG-Print in A-"odd" sizes

### DIFF
--- a/controllers/print.js
+++ b/controllers/print.js
@@ -273,6 +273,10 @@ function print(key, q, req, response, outputPng = false, frame = 0, count, retur
                                     height = 1500;
                                     break;
                             }
+                            // nobody like non-integer pixel values, make sure to round them
+                            width = Math.floor(width);
+                            height = Math.floor(height);
+                                
                             page.emulate({
                                 viewport: {width, height},
                                 userAgent: 'Puppeteer'


### PR DESCRIPTION
Given the current logic of multiplying the page size to get the height and width of the png-file, they get have a non-integer value.

This fix floors the values before they get further in the chain, preventing the print from failing.