### PR TITLE
Feat: Add ignorelist to streetView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [CalVer](https://calver.org/).
 
+## [Unreleased]
+
+### Added
+
+- A new config `extensionConfig.streetView.ignorelist`. This setting will not render the buttons for selected options. possible values. (To hide `cowi` - no not set `extensionConfig.streetView.cowi`): 
+  - streetview
+  - mapillary
+  - skraafoto
+  - maps
+
+
 ## [2025.3.2] - 2025-28-3
 
 ### Added

--- a/extensions/streetView/browser/index.js
+++ b/extensions/streetView/browser/index.js
@@ -51,6 +51,7 @@ let mapObj;
 let config = require('../../../config/config.js');
 
 let cowiUrl = config?.extensionConfig?.streetView?.cowi;
+let ignorelist = config?.extensionConfig?.streetView?.ignorelist || [];
 let mapillaryUrl = config?.extensionConfig?.streetView?.mapillary ||"https://www.mapillary.com/app/?z=17";
 
 /**
@@ -242,32 +243,51 @@ module.exports = {
                         <div className="form-group">
                             <div className="d-flex flex-column gap-4">
                                 <span className="btn-group">
-                                    <input className="btn-check" type="radio" id="streetview-service-google"
-                                           name="streetview-service"
-                                           value="google" checked={this.state.selectedOption === 'google'}
-                                           onChange={this.onChange}/>
-                                    <label className="btn btn-sm btn-outline-secondary"
-                                           htmlFor="streetview-service-google">Street View</label>
-
-                                    <input className="btn-check" type="radio" id="streetview-service-mapillary"
-                                           name="streetview-service" value="mapillary"
-                                           checked={this.state.selectedOption === 'mapillary'}
-                                           onChange={this.onChange}/>
-                                    <label className="btn btn-sm btn-outline-secondary"
-                                           htmlFor="streetview-service-mapillary">Mapillary</label>
-
-                                    <input className="btn-check" type="radio" id="streetview-service-skraafoto"
-                                           name="streetview-service" value="skraafoto"
-                                           checked={this.state.selectedOption === 'skraafoto'}
-                                           onChange={this.onChange}/>
-                                    <label className="btn btn-sm btn-outline-secondary"
-                                           htmlFor="streetview-service-skraafoto">Skråfoto</label>
-                                    <input className="btn-check" type="radio" id="streetview-service-maps"
-                                           name="streetview-service" value="maps"
-                                           checked={this.state.selectedOption === 'maps'}
-                                           onChange={this.onChange}/>
-                                    <label className="btn btn-sm btn-outline-secondary"
-                                           htmlFor="streetview-service-maps">Maps</label>
+                                {ignorelist.length > 0 && !ignorelist.includes("streetview") ?
+                                    <>
+                                        <input className="btn-check" type="radio" id="streetview-service-activate"
+                                               name="streetview-service"
+                                               value="activate" checked={this.state.selectedOption === 'activate'}
+                                               onChange={this.onChange}/>
+                                        <label className="btn btn-sm btn-outline-secondary"
+                                               htmlFor="streetview-service-activate">Street View</label>
+                                    </>
+                                    : null
+                                }
+                                {ignorelist.length > 0 && !ignorelist.includes("mapillary") ?
+                                    <>
+                                        <input className="btn-check" type="radio" id="streetview-service-mapillary"
+                                               name="streetview-service"
+                                               value="mapillary" checked={this.state.selectedOption === 'mapillary'}
+                                               onChange={this.onChange}/>
+                                        <label className="btn btn-sm btn-outline-secondary"
+                                               htmlFor="streetview-service-mapillary">Mapillary</label>
+                                    </>
+                                    : null
+                                }
+                                {ignorelist.length > 0 && !ignorelist.includes("skraafoto") ?
+                                    <>
+                                        <input className="btn-check" type="radio" id="streetview-service-skraafoto"
+                                               name="streetview-service"
+                                               value="skraafoto" checked={this.state.selectedOption === 'skraafoto'}
+                                               onChange={this.onChange}/>
+                                        <label className="btn btn-sm btn-outline-secondary"
+                                               htmlFor="streetview-service-skraafoto">Skråfoto</label>
+                                    </>
+                                    : null
+                                }
+                                {ignorelist.length > 0 && !ignorelist.includes("maps") ?
+                                    <>
+                                        <input className="btn-check" type="radio" id="streetview-service-maps"
+                                               name="streetview-service"
+                                               value="maps" checked={this.state.selectedOption === 'maps'}
+                                               onChange={this.onChange}/>
+                                        <label className="btn btn-sm btn-outline-secondary"
+                                               htmlFor="streetview-service-maps">Maps</label>
+                                    </>
+                                    : null
+                                }
+                                
                                     {cowiUrl !== undefined ?
                                         <input className="btn-check" type="radio" id="streetview-service-cowi"
                                                name="streetview-service" value="cowi"


### PR DESCRIPTION
A new config `extensionConfig.streetView.ignorelist`. This setting will not render the buttons for selected options. possible values. (To hide `cowi` - no not set `extensionConfig.streetView.cowi`): 
  - streetview
  - mapillary
  - skraafoto
  - maps