### PR TITLE
Feat: Add config for timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [CalVer](https://calver.org/).
 
+## [Unreleased]
+
+### Added
+- A new config `print.timeout` controls the timeout of the headless browser. Defaults to `60000` which equals the previously hardcoded value.
+
 ## [2025.3.2] - 2025-28-3
 
 ### Added

--- a/controllers/print.js
+++ b/controllers/print.js
@@ -14,6 +14,9 @@ const shared = require('./gc2/shared');
 const request = require('request');
 const PDFMerge = require('pdf-merge');
 const AdmZip = require('adm-zip');
+const config = require("../config/config.js");
+
+const timeout = config?.print?.timeout || 60000; // 60 seconds
 
 
 /**
@@ -142,9 +145,9 @@ function print(key, q, req, response, outputPng = false, frame = 0, count, retur
                     setTimeout(() => {
                         if (headless.isBorrowedResource(browser)) {
                             headless.destroy(browser);
-                            console.log("Destroying browser after 60 secs");
+                            console.log("Destroying browser after timeout " + timeout);
                         }
-                    }, 60000);
+                    }, timeout); 
                     if (!outputPng) {
                         browser.newPage().then(async (page) => {
                             await page.emulateMedia('screen');

--- a/docs/pages/standard/90_build_configuration.rst
+++ b/docs/pages/standard/90_build_configuration.rst
@@ -58,6 +58,15 @@ Herunder er et eksempel på en opsætning der kun giver mulighed for print i ``1
 
     "scales": [1000, 2000, 10000]
 
+.. _configjs_print_timeout:
+
+timeout
+*****************************************************************
+
+``timeout`` er en integer der angiver hvor lang tid der må gå før print-processen stopper sig selv. Det kan være nødvendigt at øge denne værdi hvis man ønsker at printe i større formater som A1 eller over. 
+
+``timeout`` er i ms og default er 60000.
+
 .. _configjs_configurl:
 
 configUrl


### PR DESCRIPTION
When printing at large scale, the default 1-minute timeout is not enough. This PR moves the time-out value into the config-element.

- [x] Changelog
- [x] Docs