### PR TITLE
Bug: encode layers in legend

### DIFF
--- a/browser/modules/legend.js
+++ b/browser/modules/legend.js
@@ -56,7 +56,7 @@ module.exports = module.exports = {
                     layers = visibleLayers;
                 }
 
-                param = 'l=' + layers + '&db=' + db;
+                param = 'l=' + encodeURIComponent(layers) + '&db=' + db;
             } else {
                 hasBeenVisible = arrayUnique([...hasBeenVisible, ...layerArr ? layerArr : visibleLayers.split(";")]);
 
@@ -66,7 +66,7 @@ module.exports = module.exports = {
                 }
 
                 hasBeenVisibleTmp = hasBeenVisible;
-                param = 'l=' + hasBeenVisible.join(";") + '&db=' + db;
+                param = 'l=' + encodeURIComponent(hasBeenVisible.join(";")) + '&db=' + db;
             }
 
             $.ajax({


### PR DESCRIPTION
When getting layers, I get wierd results - only the first or only one legend was shown. if I printed, the legends were fine.

I tracked it down to the following - what i saw in gc2, was the layers getting lost because of the ;-seperator.

using the proposed encodeURIComponent - the separator is escaped and passed on in the api as a string for gc2 to parse.