### PR TITLE
Fix: Update legends on group checkbox

### DIFF
--- a/browser/modules/bindEvent.js
+++ b/browser/modules/bindEvent.js
@@ -7,6 +7,7 @@
 'use strict';
 
 import {LAYER_TYPE_DEFAULT} from './layerTree/constants';
+import legend from './legend';
 
 require('dom-shims');
 require('arrive');
@@ -160,6 +161,7 @@ module.exports = {
                         prefix = parsedMeta?.default_layer_type && parsedMeta.default_layer_type !== 't' ? parsedMeta.default_layer_type + ':' : '';
                         setTimeout(() => {
                             switchLayer.init(prefix + e.f_table_schema + "." + e.f_table_name, isChecked, true, false);
+                            legend.init();
                         }, 1)
                         return true;
                     }

--- a/controllers/gc2/legend.js
+++ b/controllers/gc2/legend.js
@@ -13,7 +13,7 @@ router.get('/api/legend/:db', function (req, response) {
 
     var l = req.query.l, db = req.params.db, url;
 
-    url = config.host + "/api/v1/legend/json/" + db + "?l=" + l;
+    url = config.host + "/api/v1/legend/json/" + db + "?l=" + encodeURIComponent(l);
 
     var options = {
         uri: url,


### PR DESCRIPTION
This fix updates the legend-element with the active layers when a group is enabled.

This fix also includes `encodeURIComponent` on the server-side for legends, which can fail sometimes.