### PR TITLE
Bug: Ignore activeLayers from config when printing

### DIFF
--- a/browser/modules/init.js
+++ b/browser/modules/init.js
@@ -177,6 +177,10 @@ module.exports = {
                     }
                     $.getJSON(configParam, function (data) {
                         for (let prop in defaults) {
+                            // if we are printing, skip the activelayers prop
+                            if (prop === "activeLayers" && (urlVars.px || urlVars.py)) {
+                                continue;
+                            }
                             window.vidiConfig[prop] = typeof data[prop] !== 'undefined' ? data[prop] : window.vidiConfig[prop];
                         }
                     }).fail(function () {


### PR DESCRIPTION
When setting `activeLayers `in config, Vidi always reloads the layers - even when printing. this behaviour is not expected.

The snippet ignores `activeLayers` from the config file, but keeps the `activeLayers` from state - resulting in a print as expected.

Let me know if you would rather have this as a new config value with a default.

i have deployed the fix here:
https://test-mapgovidi.geopartner.dk/app/e2e/?config=/api/v2/configuration/e2e/configuration_activelayers_682d8809e0ffd095304449.json

this has the old code:
http://mapgovidi.geopartner.dk/app/vandvaerker/timvand/?config=timVand2.json
(turn off layers, then print)
