### PR TITLE
DF: Change service URLs

### DIFF
--- a/controllers/df.js
+++ b/controllers/df.js
@@ -23,7 +23,36 @@ router.get('/api/dataforsyningen/*', (req, response) => {
     const userName = config?.df?.dataforsyningen?.username;
     const pwd = config?.df?.dataforsyningen?.password;
     const token = config?.df?.dataforsyningen?.token;
-    const host = 'https://api.dataforsyningen.dk';
+    let host = 'https://api.dataforsyningen.dk';
+
+    // Due to dataforsyningen modernization, these services change their url, prefixing wms or wmts.
+    // lists updated: 2021-08-21
+    // https://dataforsyningen.dk/news/5042
+    // Live change list: https://dataforsyningen.dk/asset/PDF/Mapningstabel/dataforsyningen_api_2025.xlsx
+    let changedWMSServices = [
+        'orto_sommer_1999',
+        'orto_sommer_2002',
+        'orto_sommer_2005',
+        'orto_sommer_2008',
+        'orto_foraar_temp',
+        'forvaltning2',
+        'kommunikation',
+        'orto_foraar',
+        'grid'
+    ];
+    let changedWMTSServices = [
+        'dhm_bluespot_ekstremregn'
+    ];
+
+    let serviceName = req.url.substring('/api/dataforsyningen/'.length).split('?')[0];
+    console.log(serviceName)
+    serviceName = serviceName.replace(/^\/|\/$/g, ''); // trim leading/trailing slash
+    if (changedWMSServices.includes(decodeURIComponent(serviceName))) {
+        host += '/wms';
+    } else if (changedWMTSServices.includes(decodeURIComponent(serviceName))) {
+        host += '/wmts';
+    }
+
     let creds = token ? `&token=${token}` : `&username=${userName}&password=${pwd}`;
     let requestURL = host + decodeURIComponent(req.url.substr(20)) + creds;
     requestURL = requestURL.replace('false', 'FALSE')


### PR DESCRIPTION
Due to dataforsyningen modernization, these services change their url, prefixing wms or wmts:
https://dataforsyningen.dk/news/5042

Live change list:
https://dataforsyningen.dk/asset/PDF/Mapningstabel/dataforsyningen_api_2025.xlsx

**Routing and URL handling updates:**

* Added logic to detect if the requested service is in a list of WMS or WMTS services that now require a `/wms` or `/wmts` prefix in the host URL; the host is dynamically updated before proxying the request.
* Introduced `changedWMSServices` and `changedWMTSServices` arrays to maintain the list of affected services, making it easier to update as Dataforsyningen changes their endpoints.
* Improved extraction and normalization of the service name from the request URL to ensure correct matching and routing