### PR TITLE
Print: Wait for content

### DIFF
--- a/browser/modules/init.js
+++ b/browser/modules/init.js
@@ -113,6 +113,7 @@ module.exports = {
         // If Vidi loads, the timeout will be cleared in State
         window.loadingTimeout = setTimeout(() => {
             console.log("Timeout reached. Sending 'Vidi is now loaded' message");
+            console.log('Vidi is now loaded')
         },  window.vidiConfig.loadingTimeout);
 
         // In a interval of x seconds, check if the app is still loading. If it is, send the 'still loading' message.

--- a/browser/modules/legend.js
+++ b/browser/modules/legend.js
@@ -114,6 +114,7 @@ module.exports = module.exports = {
                         }
                     });
                     $(el ? el : '#legend').html(list);
+                    console.log("Legend is ready");
                     resolve();
                 },
                 error: function (err) {

--- a/browser/modules/state.js
+++ b/browser/modules/state.js
@@ -518,6 +518,7 @@ module.exports = {
 
                                 if (`state` in response.data && response.data.state) {
                                     if (`modules` in response.data.state && `layerTree` in response.data.state.modules && `order` in response.data.state.modules.layerTree) {
+                                        console.log(response.data.state.modules.layerTree.activeLayers.length + ' active layers in saved state');
                                         layerTree.applyState(response.data.state.modules.layerTree);
                                     }
                                 }

--- a/controllers/print.js
+++ b/controllers/print.js
@@ -143,6 +143,12 @@ function print(key, q, req, response, outputPng = false, frame = 0, count, retur
         let delay = 1000;
         const func = () => {
             headless.acquire().then(browser => {
+
+                    // Set status variables
+                    var vidiIsReady = false;
+                    var layersAreLoaded = false;
+                    var legendIsReady = false;
+
                     setTimeout(() => {
                         if (headless.isBorrowedResource(browser)) {
                             headless.destroy(browser);
@@ -166,7 +172,28 @@ function print(key, q, req, response, outputPng = false, frame = 0, count, retur
                                 }
 
                                 console.log(msg.text());
+
+                                // Check statuses 
                                 if (msg.text().indexOf(`Vidi is now loaded`) !== -1) {
+                                    vidiIsReady = true;
+                                } else if (msg.text().indexOf(`Layers all loaded`) !== -1) {
+                                    layersAreLoaded = true;
+                                // If no layers are active, we skip waiting for layers to load
+                                } else if (msg.text().indexOf(`0 active layers in saved state`) !== -1) {
+                                    layersAreLoaded = true;
+                                } else if (msg.text().indexOf(`Legend is ready`) !== -1) {
+                                    legendIsReady = true;
+                                }
+
+                                // Make sure we dont wait forever
+                                if (msg.text().indexOf(`Versioning:`) !== -1) {
+                                    vidiIsReady = true;
+                                    layersAreLoaded = true;
+                                    legendIsReady = true;
+                                }
+
+                                // for each console line, check if all are ready - then print
+                                if (layersAreLoaded && legendIsReady && vidiIsReady) {
                                     if (!check) {
                                         check = true;
                                         console.log('App was loaded, generating PDF');
@@ -299,7 +326,28 @@ function print(key, q, req, response, outputPng = false, frame = 0, count, retur
                             }).then(() => {
                                 page.on('console', msg => {
                                     console.log(msg.text());
+
+                                    // Check statuses 
                                     if (msg.text().indexOf(`Vidi is now loaded`) !== -1) {
+                                        vidiIsReady = true;
+                                    } else if (msg.text().indexOf(`Layers all loaded`) !== -1) {
+                                        layersAreLoaded = true;
+                                    // If no layers are active, we skip waiting for layers to load
+                                    } else if (msg.text().indexOf(`0 active layers in saved state`) !== -1) {
+                                        layersAreLoaded = true;
+                                    } else if (msg.text().indexOf(`Legend is ready`) !== -1) {
+                                        legendIsReady = true;
+                                    }
+
+                                    // Make sure we dont wait forever
+                                    if (msg.text().indexOf(`Versioning:`) !== -1) {
+                                        vidiIsReady = true;
+                                        layersAreLoaded = true;
+                                        legendIsReady = true;
+                                    }
+
+                                    // for each console line, check if all are ready - then print
+                                    if (layersAreLoaded && legendIsReady && vidiIsReady) {
                                         console.log('App was loaded, generating PNG');
                                         setTimeout(() => {
                                             page.evaluate(`$('.leaflet-top').remove();$('#loadscreen').remove();`).then(() => {

--- a/controllers/print.js
+++ b/controllers/print.js
@@ -176,7 +176,7 @@ function print(key, q, req, response, outputPng = false, frame = 0, count, retur
                                 // Check statuses 
                                 if (msg.text().indexOf(`Vidi is now loaded`) !== -1) {
                                     vidiIsReady = true;
-                                } else if (msg.text().indexOf(`Layers all loaded`) !== -1) {
+                                } else if (msg.text().indexOf(`Layers all loaded L`) !== -1) {
                                     layersAreLoaded = true;
                                 // If no layers are active, we skip waiting for layers to load
                                 } else if (msg.text().indexOf(`0 active layers in saved state`) !== -1) {
@@ -330,7 +330,7 @@ function print(key, q, req, response, outputPng = false, frame = 0, count, retur
                                     // Check statuses 
                                     if (msg.text().indexOf(`Vidi is now loaded`) !== -1) {
                                         vidiIsReady = true;
-                                    } else if (msg.text().indexOf(`Layers all loaded`) !== -1) {
+                                    } else if (msg.text().indexOf(`Layers all loaded L`) !== -1) {
                                         layersAreLoaded = true;
                                     // If no layers are active, we skip waiting for layers to load
                                     } else if (msg.text().indexOf(`0 active layers in saved state`) !== -1) {


### PR DESCRIPTION
We regularly get support tickets for "I am missing layers in my print". Usually this is because the plot is generated when headless browser emits "Vidi is now loaded", which may be before the layers are - especially when there are many layers.

This PR adds resilience to the printing by waiting for the "Layers all loaded L" message that is emitted when the layertree is forcibly rebuild from the hash state.

caveats:
- Vidi really should do this itself, maybe we are looking at a regression-bug?
- When a plot is generated without layers - like in the conflict-report - "Layers all loaded B" is emitted instead. This is why we look at "0 active layers in saved state" instead.
- We wait for the legend to finish, but we dont handle errors very well - leading to a hit/miss if it is even there.
- In some instances, not all 3 toggles are set, which causes the headless browser to wait and not print. In this case we finally look for "Versioning:" to set all 3.

This PR does not address the issue with missing legends in print - this problem persists, even if we wait for the legend logic to complete.